### PR TITLE
Performance improvement

### DIFF
--- a/script.js
+++ b/script.js
@@ -671,7 +671,7 @@ $(document).ready(function() {
 		
 		var checks = {
 			"ContainsTelephone": function(text) {
-				var matches = text.match(/[0-9A-Z\.\-\+]{0,15}/gi);
+				var matches = text.match(/[0-9\-\*]{7,15}/gi);
 				if(matches) {
 					for(var match in matches) {
 						var testCountries = ["US", "IN"];
@@ -709,5 +709,5 @@ $(document).ready(function() {
 		
 		return checkHits.join(', ');
 	}
-   
+	
 });


### PR DESCRIPTION
What was supposed to be a quick check (in `AnswerWarningHeuristics.checks.ContainsTelephone`):

    var matches = text.match(/[0-9A-Z\.\-\+]{0,15}/gi);

actually matched basically everything because I'm bad at regex and didn't think about it. That sort of screwed over performance... the new check is this:

    var matches = text.match(/[0-9\-\*]{7,15}/gi);

which should only match things that are much closer to being phone numbers. Testing indicates a performance improvement of several seconds.